### PR TITLE
Support browserslist + default value in `constant`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,26 +1,55 @@
-const postcss = require('postcss')
+const postcss = require('postcss');
+const browserslist = require('browserslist');
+const caniuse = require('caniuse-lite');
 
-const SAFE_AREA_VARS = ['safe-area-inset-top', 'safe-area-inset-bottom',
-  'safe-area-inset-left', 'safe-area-inset-right'];
+// Apple vars
+const vars = [
+  'safe-area-inset-top',
+  'safe-area-inset-bottom',
+  'safe-area-inset-left',
+  'safe-area-inset-right',
+];
 
 module.exports = postcss.plugin('postcss-safe-area', () => {
-  return (root) => {
+
+  // Get browser capabilities
+  const browsers = browserslist();
+  const stats = caniuse.feature(caniuse.features['css-env-function']).stats;
+  const capabilities = browsers.map(browser => {
+    const [ vendor, version ] = browser.split(' ');
+    return stats[vendor][version];
+  });
+  const useConstantFunction = capabilities.some(capability => capability === 'a #1');
+  const useDefaultValue = capabilities.some(capability => capability === 'n');
+  if (!useConstantFunction && !useDefaultValue) {
+    return () => {};
+  }
+
+  // Detects env(..., ...)
+  const expr = new RegExp(`env\\(\\s*(${vars.join('|')})\\s*,?\\s*([^)]+)?\\s*\\)`, 'g');
+  return root => {
     root.walkDecls(decl => {
-      const vars = decl.value.match(/env\(([\w-]+)\)/g) || [];
-      const match = SAFE_AREA_VARS.some(s => vars.includes(`env(${s})`));
-      if (!match) return;
-
-      let fallback1 = decl.value;
-      let fallback2 = decl.value;
-
-      for (const key of SAFE_AREA_VARS) {
-        const regex = new RegExp(`env\\(${key}\\)`, 'g');
-        fallback1 = fallback1.replace(regex, '0px');
-        fallback2 = fallback2.replace(regex, `constant(${key})`);
+      // env(..., 1px) -> 1px
+      if (useDefaultValue) {
+        const fallback = decl.value.replace(expr, (match, param, defaultValue) => {
+          return defaultValue || '0';
+        });
+        if (fallback === decl.value) {
+          return;
+        }
+        decl.before(`${decl.prop}:${fallback}`);
       }
 
-      decl.before(`${decl.prop}:${fallback1}`);
-      decl.before(`${decl.prop}:${fallback2}`);
+      // env(...) -> constant(...)
+      if (useConstantFunction) {
+        const fallback = decl.value.replace(expr, (match, param, defaultValue) => {
+          return `constant(${param}${defaultValue ? `, ${defaultValue}` : ''})`;
+        });
+        if (fallback === decl.value) {
+          return;
+        }
+        decl.before(`${decl.prop}:${fallback}`);
+      }
     });
-  }
-})
+  };
+});

--- a/index.test.js
+++ b/index.test.js
@@ -10,8 +10,8 @@ function run(input, output, opts = {}) {
 }
 
 it('adds safe area fallbacks', function() {
-  return run('a{padding-top:env(safe-area-inset-top);}',
-    'a{padding-top:0px;padding-top:constant(safe-area-inset-top);padding-top:env(safe-area-inset-top);}')
+  return run('a{padding-top:env(safe-area-inset-top, 2px);}',
+    'a{padding-top:2px;padding-top:constant(safe-area-inset-top, 2px);padding-top:env(safe-area-inset-top, 2px);}')
 })
 
 // TODO More tests for calc() and padding/margin shorthands.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "fallback"
   ],
   "scripts": {
-    "test": "jest && eslint *.js"
+    "test": "BROWSERSLIST='ios>=6' jest && eslint *.js"
   },
   "author": "Philipp Legner <philipp@mathigon.org>",
   "license": "MIT",
@@ -21,7 +21,9 @@
   },
   "homepage": "https://github.com/plegner/postcss-safe-area",
   "dependencies": {
-    "postcss": "^7.0.6"
+    "browserslist": "^4",
+    "caniuse-lite": "^1",
+    "postcss": "^7"
   },
   "devDependencies": {
     "eslint": "^5.10.0",


### PR DESCRIPTION
Support browserslist + default value in `constant`
    
- Plugin now checks browserslist so if you don't support iOS <=11.2 it
won't emit `constant(...)` functions and if you don't support <=10.3 it
won't emit anything at all.
- Default value is parsed so env(..., 5px) will be rewritten to 5px.