### PR TITLE
Add type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,5 @@
+import { PluginCreator } from "postcss";
+
+declare const postcssSafeArea: PluginCreator<{}>;
+
+export = postcssSafeArea;


### PR DESCRIPTION
This makes it easier to use this package in a Typescript context, or in a context using Typescript to check JS files.


Shipping type declarations directly in the package is the easiest way for downstream consumers.
As this plugin does not support any options, the type definitions are really simple and won't require much maintenance work.

If you prefer not including them in the package, I might submit them to DefinitelyTyped instead.
